### PR TITLE
Use unique ID to prevent conflict with multiple package install

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,7 @@
       "enzyme-to-json/serializer"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "gud": "^1.0.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
+import gud from 'gud';
 
 type RenderFn<T> = (value: T) => Node;
 
@@ -51,10 +52,8 @@ function onlyChild(children): any {
   return Array.isArray(children) ? children[0] : children;
 }
 
-let uniqueId = 0;
-
 function createReactContext<T>(defaultValue: T): Context<T> {
-  const contextProp = '__create-react-context-' + uniqueId++ + '__';
+  const contextProp = '__create-react-context-' + gud() + '__';
 
   class Provider extends Component<ProviderProps<T>> {
     emitter = createEventEmitter(this.props.value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,10 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
 handlebars@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"


### PR DESCRIPTION
Thanks for this package, it's so cool to be able to use the context with an older version of react, and it works like a charm 😄 

I use a monorepo in one of my apps, and I encountered a case where a `Consumer` picks the value from the wrong `Provider`. See the following example.
```javascript
<ContextA.Provider value="a">
  <ContextB.Provider value="b">
    <ContextA.Consumer>
      {(contextA) => /* contextA === 'b' whereas it should be 'a' */}
    </ContextA.Consumer>
  </ContextB.Provider>
</ContextA.Provider>
```

My issue was that I actually had different versions of `create-react-context` installed (`app` uses `lib` and depended on `create-react-context@1.4`, and lib depended on `create-react-context@1.6`. Upgrading both version to 1.6 actually fixed my problem. But this can be fixed on `create-react-context` side, if we don't use a locally unique id, but a global one, hence my use of `shortid`. I don't know how you feel about adding a dependency to your package, so if you'd rather fix that any other way, let me know, I'll gladly update this PR!

Testing this doesn't seem straightforward, I could perhaps add an older version of `create-react-context` as a devDependency for the purpose of the test, but it seemed a bit overkill.