### PR TITLE
Support React 15 (but not 0.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",
-    "react": "^14.0.0 || ^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,8 @@
   "repository": "https://github.com/thejameskyle/create-react-context",
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",
-  "keywords": [
-    "react",
-    "context",
-    "contextTypes",
-    "polyfill",
-    "ponyfill"
-  ],
-  "files": [
-    "lib"
-  ],
+  "keywords": ["react", "context", "contextTypes", "polyfill", "ponyfill"],
+  "files": ["lib"],
   "scripts": {
     "test": "jest",
     "flow": "flow",
@@ -27,7 +19,8 @@
   },
   "dependencies": {
     "fbjs": "^0.8.0",
-    "gud": "^1.0.0"
+    "gud": "^1.0.0",
+    "react-dot-fragment": "^0.2.2"
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",
@@ -54,14 +47,9 @@
     "react-dom": "^16.2.0"
   },
   "lint-staged": {
-    "*.{js,md,json,js.flow,d.ts}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,md,json,js.flow,d.ts}": ["prettier --write", "git add"]
   },
   "jest": {
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -3,6 +3,7 @@ import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 import gud from 'gud';
 import warning from 'fbjs/lib/warning';
+import Fragment from 'react-dot-fragment';
 
 const MAX_SIGNED_31_BIT_INT = 1073741823;
 
@@ -117,7 +118,7 @@ function createReactContext<T>(
     }
 
     render() {
-      return this.props.children;
+      return <Fragment>{this.props.children}</Fragment>;
     }
   }
 
@@ -173,7 +174,9 @@ function createReactContext<T>(
     };
 
     render() {
-      return onlyChild(this.props.children)(this.state.value);
+      return (
+        <Fragment>{onlyChild(this.props.children)(this.state.value)}</Fragment>
+      );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,6 +3074,10 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-dot-fragment@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/react-dot-fragment/-/react-dot-fragment-0.2.2.tgz#5ca16a7c42a944577dc5a9d170cfb29212c7aebb"
+
 react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"


### PR DESCRIPTION
I noticed while I was testing a project that relies on create-react-context that it only supports React 16+ (despite what it says in the package.json) - it directly returns `this.props.children` in the render methods which isn't always supported in React 15.

The naive solution would be something like:

```jsx
render() {
  return typeof React.Fragment === 'function'
    ? this.props.children
    : <div>{this.props.children}</div>;
}
```

However I tried this out for my own library on React 15 and it totally mangled the layout. I imagine this could be a common problem - we really want to be able to guarantee the same layout as with React 16.

To get around this I wrote a [ponyfill of `React.Fragment`](https://github.com/benwiley4000/react-dot-fragment) which works with React 15 and defaults to the native `React.Fragment` if it's available. The source code [is very tiny](https://github.com/benwiley4000/react-dot-fragment/blob/master/index.js).

I just finished writing this, so it's definitely possible there are bugs I don't know about. One drawback is it generates an extra empty `<div>` in the DOM, but it's set to `display: 'none'`, so I would consider the drawback minimal.

I locally confirmed that this works with React 15 (at least, the example app behaves correctly). My module doesn't work with React 0.14 so I removed that from the package.json spec for create-react-context, unless you're compelled to learn how to support it.