### PR TITLE
Update version for next release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-context",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Polyfill for the proposed React context API",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Please, release patch that get rid of that line in src/implementation.js file.
```javascript
export default React.createContext || createReactContext;
```
This is already fixed in commit 27e96938f58c958b8d3c0ac261ea947d22fd9f8a however it's not published.

I'm kindly asking for that, because `enzyme-adapter-16` does not support React 16 Context API and it will just make it easier to workaround and use the actual polyfill instead of native implementation.

So once this is merged or declined, but new version form `master` released, it will be possible to do:
```javascript
import createContext from 'create-react-context/lib/implementation';
```
so it's guaranteed that you use the polyfill - not the native implementation.