### PR TITLE
fix TypeScript typings exports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,23 +1,27 @@
 import * as React from 'react';
 
-export default function createReactContext<T>(
+export = createReactContext;
+
+declare function createReactContext<T>(
   defaultValue: T,
   calculateChangedBits?: (prev: T, next: T) => number
-): Context<T>;
+): createReactContext.Context<T>;
 
 type RenderFn<T> = (value: T) => React.ReactNode;
 
-export type Context<T> = {
-  Provider: React.ComponentClass<ProviderProps<T>>;
-  Consumer: React.ComponentClass<ConsumerProps<T>>;
-};
+declare namespace createReactContext {
+  export type Context<T> = {
+    Provider: React.ComponentClass<ProviderProps<T>>;
+    Consumer: React.ComponentClass<ConsumerProps<T>>;
+  };
 
-export type ProviderProps<T> = {
-  value: T;
-  children: React.ReactNode;
-};
+  export type ProviderProps<T> = {
+    value: T;
+    children: React.ReactNode;
+  };
 
-export type ConsumerProps<T> = {
-  children: RenderFn<T> | [RenderFn<T>];
-  observedBits?: number;
-};
+  export type ConsumerProps<T> = {
+    children: RenderFn<T> | [RenderFn<T>];
+    observedBits?: number;
+  };
+}


### PR DESCRIPTION
Hi,

So this one is pretty interesting - currently it seems like you expect people to import `create-react-context` this way (because declaration file specifies `export default ...`):

```ts
import createReactContext from 'create-react-context';
```

The TypeScript compilation result is:

```js
// my-app/context.js
var create_react_context_1 = require("create-react-context");
exports.context = create_react_context_1.default(null);
```

However, in `create-react-context` production (transpiled) version, we have:

```js
// create-react-context/lib/index.js
exports.default = _react2.default.createContext || _implementation2.default;
// this is the problematic line
module.exports = exports['default'];
```

So obviously previous `create_react_context_1.default` is undefined.

Two possible solutions (1) dropping the `module.exports` line (happens due to [this](https://github.com/59naga/babel-plugin-add-module-exports) plugin), or (2) accept this PR, and then client would import this way:

```ts
import * as createReactContext from 'create-react-context';
// or:
import createReactContext = require('create-react-context');
```

Dropping `module.exports` means that clients who don't use es2015 modules would've to import this way:

```js
const {default: createReactContext} = require('create-react-context');
```

... and maybe it's a breaking change (although it's not documented).

I suggest to accept this PR (and keep `module.export` - PR is based on having it), as typings are broken anyway - no idea how people use it in current state.

@jamiebuilds please.