### PR TITLE
Update TypeScript defs to match React

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,7 @@ export type Context<T> = {
 
 export type ProviderProps<T> = {
   value: T;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type ConsumerProps<T> = {


### PR DESCRIPTION
React's definitions defines [children as optional](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/03eede695193d0d78291cee1262f7d59aa7fd4f9/types/react/index.d.ts#L246-L251) for the `<Provider />` just updating to keep these in sync.

