### PR TITLE
Use the warning package instead of fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "commit": "lint-staged"
   },
   "dependencies": {
-    "fbjs": "^0.8.0",
-    "gud": "^1.0.0"
+    "gud": "^1.0.0",
+    "warning": "^4.0.3"
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -2,7 +2,7 @@
 import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 import gud from 'gud';
-import warning from 'fbjs/lib/warning';
+import warning from 'warning';
 
 const MAX_SIGNED_31_BIT_INT = 1073741823;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,7 +1421,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.16:
+fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3682,6 +3682,13 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
React recently removed the dependency of fbjs (https://github.com/facebook/react/pull/13069, not yet released). It's always been recommended that other packages shouldn't rely on it either.

At this point it'd pull in quite a bit of code so I simply exchanged it for the `warning` package.

Note I had to use version 3 of `warning` as 4 seems to have a bug with additional arguments.